### PR TITLE
Wrap transition in supports

### DIFF
--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -4,9 +4,9 @@ $_right: odd
 @mixin Heidelberg($perspective, $duration: 1s, $timing: ease)
   &
     perspective: $perspective
-
-  & .Heidelberg-Page
-    transition: transform $duration $timing
+  @supports(transition: transform $duration $timing)
+    & .Heidelberg-Page
+      transition: transform $duration $timing
 
 // Instantiate default Heidelberg
 .Heidelberg-Book


### PR DESCRIPTION
There are issues with older browsers when using the transition property on the book – and by wrapping the transition declaration in a `@supports()` parameter, we can only target the most modern browsers with the transition effect. Older browsers still get the layout/pages, but just none of the turning magic.